### PR TITLE
Improved robustness of log formatting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       versionType:
-        description: "Version type (minor or patch)"
+        description: "Version type (patch or minor)"
         required: true
         type: choice
         options:
-          - minor
           - patch
+          - minor
 
 jobs:
   publish:
@@ -27,6 +27,8 @@ jobs:
         with:
           node-version: 18
           check-latest: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update npm
         run: npm install -g npm@latest
@@ -39,12 +41,12 @@ jobs:
           git config --global user.email "dev@mynth.ai"
           git config --global user.name "Mynth Publisher"
           npm version ${{ github.event.inputs.versionType }} -m "chore(release): bump to %s version"
-          git push --follow-tags
 
       - name: Build
         run: npm run build
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push to git repo
+        run: git push --follow-tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
+        "flatted": "^3.3.1",
         "pino": "^8.19.0"
       },
       "devDependencies": {
@@ -2728,8 +2729,7 @@
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
+    "flatted": "^3.3.1",
     "pino": "^8.19.0"
   },
   "devDependencies": {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -47,7 +47,7 @@ const formatItem = (item: unknown): string => {
 
   const stringified = (() => {
     try {
-      return stringify(item);
+      return stringify(item).slice(1).slice(0, -1);
     } catch {
       return String(item);
     }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -21,8 +21,7 @@ type Params = {
   targets?: Target[];
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const formatItem = (item: any): string => {
+const formatItem = (item: unknown): string => {
   if (typeof item === "undefined") {
     return "undefined";
   }
@@ -32,6 +31,18 @@ const formatItem = (item: any): string => {
     // eslint-disable-next-line no-control-regex
     return item.replace(/\x1b\[[0-9;]*m/g, "");
   }
+
+  // Check if this is an Error
+  if (
+    item &&
+    typeof item === "object" &&
+    "message" in item &&
+    typeof item.message === "string"
+  )
+    return item.message;
+
+  // Check if this is a string
+  if (typeof item === "string") return item;
 
   let stringified = "";
 
@@ -44,8 +55,7 @@ const formatItem = (item: any): string => {
   return stringified.replace(/^'|'$/g, "");
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const format = (items: any[]): string => {
+const format = (items: unknown[]): string => {
   return Array.from(items)
     .map((item) => formatItem(item))
     .join(" ");

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,4 +1,5 @@
 import pino, { Logger, LoggerOptions } from "pino";
+import { stringify } from "flatted";
 
 type AwaitableLogger = Logger & {
   untilFinished: Promise<void>;
@@ -44,13 +45,13 @@ const formatItem = (item: unknown): string => {
   // Check if this is a string
   if (typeof item === "string") return item;
 
-  let stringified = "";
-
-  try {
-    stringified = JSON.stringify(item) || String(item);
-  } catch {
-    stringified = String(item);
-  }
+  const stringified = (() => {
+    try {
+      return stringify(item);
+    } catch {
+      return String(item);
+    }
+  })();
 
   return stringified.replace(/^'|'$/g, "");
 };

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -1,9 +1,5 @@
 import { setupLogging } from "../src/index";
 
-const errorFunc = () => {
-  throw new Error("An error was thrown");
-};
-
 const run = async () => {
   setupLogging();
 
@@ -14,9 +10,21 @@ const run = async () => {
   console.error("Hello, this is an error log");
 
   try {
-    errorFunc();
+    throw new Error("An Error was thrown");
   } catch (error) {
     console.error(error);
+  }
+
+  try {
+    throw "A string was thrown";
+  } catch (error) {
+    console.error(error);
+  }
+
+  try {
+    throw 10n;
+  } catch (error) {
+    console.error("A bigint was thrown:", error);
   }
 };
 

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -1,0 +1,23 @@
+import { setupLogging } from "../src/index";
+
+const errorFunc = () => {
+  throw new Error("An error was thrown");
+};
+
+const run = async () => {
+  setupLogging();
+
+  console.log("Hello, this is a log");
+  console.info("Hello, this is an info log");
+  console.debug("Hello, this is a debug log");
+  console.warn("Hello, this is a warn log");
+  console.error("Hello, this is an error log");
+
+  try {
+    errorFunc();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+run();

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -44,7 +44,8 @@ const run = async () => {
   console.log(new MyObject("without a prefix", 100));
 
   try {
-    throw MyObject("Error invoking", 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    throw (MyObject as any)("Error invoking", 1);
   } catch (error) {
     console.error(error);
   }

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -41,6 +41,21 @@ const run = async () => {
   }
 
   console.log("This is MyObject", new MyObject("a", 3));
+  console.log(new MyObject("without a prefix", 100));
+
+  try {
+    throw MyObject("Error invoking", 1);
+  } catch (error) {
+    console.error(error);
+  }
+
+  try {
+    throw new MyObject("This is a custom error", 1);
+  } catch (error) {
+    console.error(error);
+  }
+
+  console.log("This is concatenating an object", {});
 };
 
 run();

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -26,6 +26,21 @@ const run = async () => {
   } catch (error) {
     console.error("A bigint was thrown:", error);
   }
+
+  try {
+    throw { msg: "This is a non-standard error" };
+  } catch (error) {
+    console.error(error);
+  }
+
+  class MyObject {
+    constructor(
+      public a: string,
+      public b: number
+    ) {}
+  }
+
+  console.log("This is MyObject", new MyObject("a", 3));
 };
 
 run();


### PR DESCRIPTION
Made the formatting for logs more robust, specifically helping in the case where we see `{}` in the logs.

Before:
![image](https://github.com/MynthAI/mynth-logger/assets/131367121/1f3b3358-7c9e-4ece-9910-9742c594bcd9)

After:
![image](https://github.com/MynthAI/mynth-logger/assets/131367121/661cea12-f9d2-49fa-994a-4585a0ced654)
