### PR TITLE
Handling bigint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,13 +54,13 @@
     "no-constant-condition": "off",
     "file-extension-in-import-ts/file-extension-in-import-ts": "error",
     "import/no-unresolved": ["error", { "ignore": ["\\.js$"] }],
-    "no-restricted-imports": ["error", { "patterns": ["src/*"] }]
+    "no-restricted-imports": ["error", { "patterns": ["src/*"] }],
+    "import/no-unresolved": "off"
   },
   "overrides": [
     {
       "files": ["tests/**/*.ts"],
       "rules": {
-        "import/no-unresolved": "off",
         "file-extension-in-import-ts/file-extension-in-import-ts": "off",
         "ava/no-ignored-test-files": "off"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
+        "@ungap/structured-clone": "^1.2.0",
         "axios": "^1.6.8",
-        "flatted": "^3.3.1",
         "pino": "^8.19.0"
       },
       "devDependencies": {
         "@types/node": "^20.5.0",
+        "@types/ungap__structured-clone": "^1.2.0",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
         "ava": "^5.3.1",
         "concurrently": "^8.2.0",
@@ -596,6 +597,13 @@
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
     },
+    "node_modules/@types/ungap__structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
+      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
@@ -791,7 +799,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "license": "ISC"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2729,7 +2737,8 @@
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
     "url": "git@github.com-mynth:MynthAI/mynth-logger.git"
   },
   "dependencies": {
+    "@ungap/structured-clone": "^1.2.0",
     "axios": "^1.6.8",
-    "flatted": "^3.3.1",
     "pino": "^8.19.0"
   },
   "devDependencies": {
     "@types/node": "^20.5.0",
+    "@types/ungap__structured-clone": "^1.2.0",
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "ava": "^5.3.1",
     "concurrently": "^8.2.0",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,5 @@
 import pino, { Logger, LoggerOptions } from "pino";
-import { stringify } from "flatted";
+import { stringify } from "@ungap/structured-clone/json";
 
 type AwaitableLogger = Logger & {
   untilFinished: Promise<void>;
@@ -47,7 +47,7 @@ const formatItem = (item: unknown): string => {
 
   const stringified = (() => {
     try {
-      return stringify(item).slice(1).slice(0, -1);
+      return stringify(item);
     } catch {
       return String(item);
     }

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -57,6 +57,8 @@ const run = async () => {
   }
 
   console.log("This is concatenating an object", {});
+
+  console.log("This is an object with bigint", { name: "bigint", value: 100n });
 };
 
 run();


### PR DESCRIPTION
Before:
![image](https://github.com/MynthAI/mynth-logger/assets/131367121/ad85176d-1dc4-44e1-9d84-385f315dc0a6)

After:
![image](https://github.com/MynthAI/mynth-logger/assets/131367121/bee6de52-df69-4daa-8145-434601dd2b49)

This will help remove `[object Object]` from our logs. Granted, this is significantly less human readable. However, it's more robust and we can copy and paste this into a parser to reconstruct data types.