### PR TITLE
Updated arktype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "peerDependencies": {
         "@arktype/schema": ">=0.1.8",
         "@arktype/util": ">=0.0.45",
-        "arktype": ">=2.0.0-dev.17"
+        "arktype": "^2.0.0-beta.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -41,6 +41,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@ark/schema": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.2.1.tgz",
+      "integrity": "sha512-1ZEpMV3dmK+UmgsNXS7BkdUkdoyzz7Y3cuku9gLdntGAz4WqJWhoHwUtjvY/xcfqPfRuJhG8m//xaMJjLlLAEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ark/util": "0.1.1"
+      }
+    },
+    "node_modules/@ark/util": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.1.1.tgz",
+      "integrity": "sha512-dmMJ5gC14NaBtsFqL8hbmWRBPz9yfZooXiMMHhyfZrxFaDuFtpN3gBxB/xA9eEK21A03x7cu7fG2wpByxi8Xvw==",
+      "peer": true
     },
     "node_modules/@arktype/schema": {
       "version": "0.1.9",
@@ -723,14 +739,14 @@
       "license": "Python-2.0"
     },
     "node_modules/arktype": {
-      "version": "2.0.0-dev.17",
-      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.0.0-dev.17.tgz",
-      "integrity": "sha512-JvWPpVkfPDvd4hcDZg3YrqRIJ6McbASKo84S/ZlDvyyFCbc8FRFekS8d5amvVZCH3lgXJbDvDLkCFiJeewUdZQ==",
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.0.0-beta.1.tgz",
+      "integrity": "sha512-ztMquaiJR7HPks6ojXYwVw5qvXyt81v6vD++E5JQSFGD/556I1StFYYmicJS1jm5oiECCLAscYQFX6V3tsoHow==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@arktype/schema": "0.1.9",
-        "@arktype/util": "0.0.46"
+        "@ark/schema": "0.2.1",
+        "@ark/util": "0.1.1"
       }
     },
     "node_modules/array-buffer-byte-length": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@arktype/schema": ">=0.1.8",
     "@arktype/util": ">=0.0.45",
-    "arktype": ">=2.0.0-dev.17"
+    "arktype": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@ungap/structured-clone": "^1.2.0",


### PR DESCRIPTION
ArkType 2.0.0-beta has been released, so updating the peer dependency for mynth-logger