### PR TITLE
Allow Discord webhook URL to be configured globally

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,7 +21,7 @@ jobs:
           check-latest: true
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@"<11"
 
       - name: Install dependencies
         run: npm ci --include dev
@@ -43,7 +43,7 @@ jobs:
           check-latest: true
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@"<11"
 
       - name: Install dependencies
         run: npm ci --include dev
@@ -66,7 +66,7 @@ jobs:
           check-latest: true
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@"<11"
 
       - name: Install dependencies
         run: npm install --include dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           check-latest: true
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@"<11"
 
       - name: Install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^5.6.2"
       },
       "peerDependencies": {
-        "arktype": "^2.0.0-rc.7"
+        "arktype": "^2.0.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -41,19 +41,20 @@
       }
     },
     "node_modules/@ark/schema": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.9.0.tgz",
-      "integrity": "sha512-pHA+BNGICGKhKG0hEdmjJbt8yQwJnDaPD5R8nq16TXTTzuGZcroTPBXEquSVaCoAqnXwx+Skae/63D1MpDnuow==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.39.0.tgz",
+      "integrity": "sha512-LQbQUb3Sj461LgklXObAyUJNtsUUCBxZlO2HqRLYvRSqpStm0xTMrXn51DwBNNxeSULvKVpXFwoxiSec9kwKww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ark/util": "0.9.0"
+        "@ark/util": "0.39.0"
       }
     },
     "node_modules/@ark/util": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.9.0.tgz",
-      "integrity": "sha512-iwfIpS8EKLNRyJyurLYS66321qZSJupXlolGmU94FQ58lcgpRaK+BVQYYsJiuLj9kULxHVpQkI8bVmEvU3Sbsg==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.39.0.tgz",
+      "integrity": "sha512-90APHVklk8BP4kku7hIh1BgrhuyKYqoZ4O7EybtFRo7cDl9mIyc/QUbGvYDg//73s0J2H0I/gW9pzroA1R4IBQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1107,14 +1108,14 @@
       "license": "Python-2.0"
     },
     "node_modules/arktype": {
-      "version": "2.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.0.0-rc.7.tgz",
-      "integrity": "sha512-O+bHkuglFJ/4O8vvhZlEQScpDT5aLqfUAqmXgt4vZ2g4IfTLEtu2paUomZTqKsUJqn5JBMIy9XJ/+lX0aad3LA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.0.4.tgz",
+      "integrity": "sha512-S68rWVDnJauwH7/QCm8zCUM3aTe9Xk6oRihdcc3FSUAtxCo/q1Fwq46JhcwB5Ufv1YStwdQRz+00Y/URlvbhAQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ark/schema": "0.9.0",
-        "@ark/util": "0.9.0"
+        "@ark/schema": "0.39.0",
+        "@ark/util": "0.39.0"
       }
     },
     "node_modules/array-buffer-byte-length": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git@github.com-mynth:MynthAI/mynth-logger.git"
   },
   "peerDependencies": {
-    "arktype": "^2.0.0-rc.7"
+    "arktype": "^2.0.4"
   },
   "dependencies": {
     "@ungap/structured-clone": "^1.2.0",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,8 +1,8 @@
 import { createConsola, ConsolaOptions } from "consola";
 import DatadogReporter from "./reporters/datadog.js";
-import DiscordReporter from "./reporters/discord.js";
+import DiscordReporter, { DiscordWebhookUrl } from "./reporters/discord.js";
 
-const setupLogging = () => {
+const setupLogging = (discordWebhookUrl?: DiscordWebhookUrl) => {
   const consola = createConsola({ fancy: true, level: 5 } as Options);
 
   if (process.env.NODE_ENV === "production")
@@ -11,7 +11,10 @@ const setupLogging = () => {
   // Set Discord reporter as first so it can remove
   // Discord-related config before other reporters process the
   // log
-  consola.setReporters([DiscordReporter, ...consola.options.reporters]);
+  consola.setReporters([
+    DiscordReporter(discordWebhookUrl),
+    ...consola.options.reporters,
+  ]);
 
   consola.wrapConsole();
   return consola;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,8 +1,8 @@
 import { createConsola, ConsolaOptions } from "consola";
 import DatadogReporter from "./reporters/datadog.js";
-import DiscordReporter, { DiscordWebhookUrl } from "./reporters/discord.js";
+import DiscordReporter from "./reporters/discord.js";
 
-const setupLogging = (discordWebhookUrl?: DiscordWebhookUrl) => {
+const setupLogging = () => {
   const consola = createConsola({ fancy: true, level: 5 } as Options);
 
   if (process.env.NODE_ENV === "production")
@@ -11,10 +11,7 @@ const setupLogging = (discordWebhookUrl?: DiscordWebhookUrl) => {
   // Set Discord reporter as first so it can remove
   // Discord-related config before other reporters process the
   // log
-  consola.setReporters([
-    DiscordReporter(discordWebhookUrl),
-    ...consola.options.reporters,
-  ]);
+  consola.setReporters([DiscordReporter, ...consola.options.reporters]);
 
   consola.wrapConsole();
   return consola;

--- a/src/reporters/discord.ts
+++ b/src/reporters/discord.ts
@@ -3,14 +3,11 @@ import { format } from "../format.js";
 import { type } from "arktype";
 import got from "got";
 
-const DiscordWebhookUrl = type("string.url");
-type DiscordWebhookUrl = typeof DiscordWebhookUrl.infer;
-
 const Discord = type({
   discord: type("boolean").narrow((v) => v),
   color: "string",
   title: "string",
-  "webhookUrl?": DiscordWebhookUrl,
+  webhookUrl: "string",
 });
 
 type Discord = typeof Discord.infer;
@@ -19,30 +16,17 @@ const NullDiscord = { discord: false } as const;
 
 type NullDiscord = typeof NullDiscord;
 
-const Reporter = ($discordWebhookUrl?: DiscordWebhookUrl) => {
-  if ($discordWebhookUrl) DiscordWebhookUrl.assert($discordWebhookUrl);
+const Reporter = {
+  log: (logObj: LogObject) => {
+    const [discord, args] = getDiscord(logObj.args);
+    if (!discord.discord) return;
 
-  return {
-    log: (logObj: LogObject) => {
-      const [discord, args] = getDiscord(logObj.args);
-      if (!discord.discord) return;
+    sendToDiscord(format(args), discord);
 
-      const discordWebhookUrl = discord.webhookUrl || $discordWebhookUrl;
-
-      if (!discordWebhookUrl) {
-        console.error(
-          "Unable to send message to Discord because webhook URL is missing"
-        );
-        return;
-      }
-
-      sendToDiscord(format(args), discord, discordWebhookUrl);
-
-      // Filter Discord data before the other reporters
-      // process the message
-      logObj.args = args;
-    },
-  };
+    // Filter Discord data before the other reporters
+    // process the message
+    logObj.args = args;
+  },
 };
 
 const getDiscord = (args: unknown[]): [Discord | NullDiscord, unknown[]] => {
@@ -56,11 +40,7 @@ const getDiscord = (args: unknown[]): [Discord | NullDiscord, unknown[]] => {
   return [NullDiscord, args];
 };
 
-const sendToDiscord = async (
-  description: string,
-  options: Discord,
-  webhookUrl: DiscordWebhookUrl
-) => {
+const sendToDiscord = async (description: string, options: Discord) => {
   const data = {
     json: {
       embeds: [
@@ -75,11 +55,10 @@ const sendToDiscord = async (
   };
 
   try {
-    await got.post(webhookUrl, data);
+    await got.post(options.webhookUrl, data);
   } catch (error) {
     console.error("Unable to send message to Discord", error);
   }
 };
 
 export default Reporter;
-export { DiscordWebhookUrl };

--- a/src/reporters/discord.ts
+++ b/src/reporters/discord.ts
@@ -4,10 +4,10 @@ import { type } from "arktype";
 import got from "got";
 
 const Discord = type({
-  discord: type("boolean").narrow((v) => v),
+  discord: "true",
   color: "string",
   title: "string",
-  webhookUrl: "string",
+  webhookUrl: "string.url",
 });
 
 type Discord = typeof Discord.infer;

--- a/src/reporters/discord.ts
+++ b/src/reporters/discord.ts
@@ -24,6 +24,11 @@ type NullDiscord = typeof NullDiscord;
 const Reporter = {
   webhookUrl: "",
   log: (logObj: LogObject) => {
+    if (configureDiscord(logObj.args)) {
+      logObj.args = ["Set Discord webhook URL"];
+      return;
+    }
+
     const [discord, args] = getDiscord(logObj.args);
     if (!discord.discord) return;
 
@@ -42,15 +47,21 @@ const Reporter = {
   },
 };
 
-const getDiscord = (args: unknown[]): [Discord | NullDiscord, unknown[]] => {
-  for (let i = 0; i < args.length; i++) {
-    const config = ConfigureDiscord(args[i]);
+const configureDiscord = (args: unknown[]): boolean => {
+  for (const arg of args) {
+    const config = ConfigureDiscord(arg);
 
     if (!(config instanceof type.errors)) {
       Reporter.webhookUrl = config.setWebhookUrl;
-      continue;
+      return true;
     }
+  }
 
+  return false;
+};
+
+const getDiscord = (args: unknown[]): [Discord | NullDiscord, unknown[]] => {
+  for (let i = 0; i < args.length; i++) {
     const discord = Discord(args[i]);
     if (discord instanceof type.errors) continue;
 


### PR DESCRIPTION
In this PR I propose allowing Discord webhook URL to be configured for all Discord log requests by passing `{ discord: true, setWebhookUrl: "[url]" }`. Example usage:
```ts
console.debug({
  discord: true,
  setWebhookUrl: "***",
});
console.log("Testing Discord integration", {
  discord: true,
  color: "2404635",
  title: "This is a test",
});
```