### PR TITLE
Add deep secret redaction in production logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@ast-grep/cli": "^0.40.5",
     "@biomejs/biome": "^2.4.2",
     "@types/node": "^25.2.3",
-    "@types/ungap__structured-clone": "^1.2.0",
     "convert-to-arrow": "^1.0.21",
     "npm-run-all": "^4.1.5",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "arktype": "^2.1.29"
   },
   "dependencies": {
+    "@hackylabs/deep-redact": "^3.0.4",
     "@ungap/structured-clone": "^1.3.0",
     "consola": "^3.4.2",
     "got": "^14.6.6"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@hackylabs/deep-redact": "^3.0.4",
+    "@scure/bip39": "^2.0.1",
     "@ungap/structured-clone": "^1.3.0",
     "consola": "^3.4.2",
     "got": "^14.6.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hackylabs/deep-redact':
         specifier: ^3.0.4
         version: 3.0.4
+      '@scure/bip39':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ungap/structured-clone':
         specifier: ^1.3.0
         version: 1.3.0
@@ -332,6 +335,10 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -481,6 +488,12 @@ packages:
     resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -1586,6 +1599,8 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@noble/hashes@2.0.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1672,6 +1687,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
+
+  '@scure/base@2.0.0': {}
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hackylabs/deep-redact':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@ungap/structured-clone':
         specifier: ^1.3.0
         version: 1.3.0
@@ -318,6 +321,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hackylabs/deep-redact@3.0.4':
+    resolution: {integrity: sha512-N0YS4KgBfoqwt90BwjPTDGriZUEFG0xKcU5DI/qKR6d8X731Ump/7sSefUMkccbS6MZ3P9T65ED99KHnn06FEA==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -1577,6 +1583,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@hackylabs/deep-redact@3.0.4': {}
 
   '@isaacs/cliui@9.0.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
-      '@types/ungap__structured-clone':
-        specifier: ^1.2.0
-        version: 1.2.0
       convert-to-arrow:
         specifier: ^1.0.21
         version: 1.0.21
@@ -512,9 +509,6 @@ packages:
 
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
-
-  '@types/ungap__structured-clone@1.2.0':
-    resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1705,8 +1699,6 @@ snapshots:
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/ungap__structured-clone@1.2.0': {}
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,3 @@
-import { DeepRedact } from "@hackylabs/deep-redact/index.ts";
 import { stringify } from "@ungap/structured-clone/json";
 import { type } from "arktype";
 
@@ -7,226 +6,27 @@ const ErrorType = type({
   "stack?": "string",
 });
 
-const stripAnsi = (s: string) =>
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-  s.replace(/\x1b\[[0-9;]*m/g, "");
-
-const replaceAll = (pattern: RegExp, replacement: string) => (value: string) =>
-  value.replace(pattern, replacement);
-
-const redactKeyValuePairs = (value: string) =>
-  value
-    // Bearer tokens
-    .replace(/\b(Bearer)\s+([A-Za-z0-9\-._~+/]+=*)/gi, "$1 [REDACTED]")
-    // Basic auth header payload
-    .replace(/\b(Basic)\s+([A-Za-z0-9+/=]+)\b/gi, "$1 [REDACTED]")
-    // URL user:pass@
-    .replace(
-      /\/\/([^/:\s]+):([^@/\s]+)@/g,
-      (_m, user) => `//${user}:[REDACTED]@`,
-    )
-    // query params that commonly hold secrets
-    .replace(
-      /([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|auth|authorization|signature|sig|key|secret|password)=)([^&]+)/gi,
-      "$1[REDACTED]",
-    )
-    // generic key=value / key: value
-    .replace(
-      /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|passwd|pwd|private[_-]?key|seed(_|-)?phrase|mnemonic)\b\s*([:=])\s*([^\s'"]+)/gi,
-      (_m, k, sep) => `${k}${sep} [REDACTED]`,
-    );
-
-// Heuristic: likely a seed phrase (12/15/18/21/24 words), especially if labeled
-const redactSeedPhrasesInText = (text: string) => {
-  // Label-based (strong signal)
-  const labeled =
-    /(mnemonic|seed\s*phrase|recovery\s*phrase|secret\s*phrase)\s*[:=]\s*([a-zA-Z]+(?:\s+[a-zA-Z]+){11,23})/gi;
-  text = text.replace(
-    labeled,
-    (_m, label) => `${label}: [REDACTED_SEED_PHRASE]`,
-  );
-
-  // Unlabeled heuristic (weaker, but requested “broad”): redact *only* if it looks like
-  // a standalone phrase (line-ish) with common word counts.
-  const counts = new Set([12, 15, 18, 21, 24]);
-  return text.replace(
-    /(^|[\n\r\t ])([a-z]+(?: [a-z]+){11,23})(?=($|[\n\r\t ]))/g,
-    (m, lead: string, phrase: string) => {
-      const words = phrase.trim().split(/\s+/);
-      if (!counts.has(words.length)) return m;
-      // extra guard to reduce false positives: average word length in typical mnemonics is small-ish
-      const avgLen = words.reduce((a, w) => a + w.length, 0) / words.length;
-      if (avgLen < 3 || avgLen > 8) return m;
-      return `${lead}[REDACTED_SEED_PHRASE]`;
-    },
-  );
-};
-
-const redactor = new DeepRedact({
-  serialise: false,
-  retainStructure: true,
-
-  caseSensitiveKeyMatch: false,
-  fuzzyKeyMatch: true,
-
-  replacement: "[REDACTED]",
-
-  blacklistedKeys: [
-    // common secrets
-    "password",
-    "passwd",
-    "pwd",
-    "pass",
-    "secret",
-    "clientSecret",
-    "privateKey",
-    "apiKey",
-    "apikey",
-    "accessKey",
-    "access_key",
-    "accessToken",
-    "access_token",
-    "refreshToken",
-    "refresh_token",
-    "idToken",
-    "id_token",
-    "token",
-    "authorization",
-    "auth",
-    "cookie",
-    "set-cookie",
-    "session",
-    "sessionid",
-    "session_id",
-
-    // seed phrases / mnemonics
-    "mnemonic",
-    "seedPhrase",
-    "seed_phrase",
-    "recoveryPhrase",
-    "recovery_phrase",
-
-    // headers / env-ish
-    "x-api-key",
-    "x-api-token",
-    "x-auth-token",
-
-    // regex patterns for “key-like” fields
-    {
-      key: /(^|[_-])(api[_-]?key|token|secret|pass(word)?|passwd|pwd|private[_-]?key|auth(orization)?|cookie|session|mnemonic|seed(_|-)?phrase|recovery(_|-)?phrase)([_-]|$)/i,
-    },
-  ],
-
-  stringTests: [
-    // PEM private keys (RSA/EC/DSA/OPENSSH and generic)
-    {
-      pattern:
-        /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
-      replacer: replaceAll(
-        /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
-        "[REDACTED_PRIVATE_KEY]",
-      ),
-    },
-
-    // JWTs
-    {
-      pattern:
-        /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/g,
-      replacer: () => "[REDACTED_JWT]",
-    },
-
-    // Ethereum private key (32 bytes hex; often with 0x)
-    {
-      pattern:
-        /(^|[^a-fA-F0-9])(0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64})(?![a-fA-F0-9])/g,
-      replacer: (value) =>
-        value.replace(
-          /0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64}/g,
-          "[REDACTED_ETH_PRIVATE_KEY]",
-        ),
-    },
-
-    // “64-bit hex strings” (16 hex chars) + other long hex blobs commonly used as secrets.
-    // (This is intentionally broad; remove if too noisy.)
-    {
-      pattern: /\b(?:0x)?[a-fA-F0-9]{16}\b/g,
-      replacer: () => "[REDACTED_HEX]",
-    },
-    {
-      // long hex (>=32) often secrets, hashes, or keys
-      pattern: /\b(?:0x)?[a-fA-F0-9]{32,}\b/g,
-      replacer: () => "[REDACTED_HEX_LONG]",
-    },
-
-    // Solana secret key as base58 string (commonly ~88 chars when encoding 64 bytes)
-    {
-      pattern: /\b[1-9A-HJ-NP-Za-km-z]{80,90}\b/g,
-      replacer: () => "[REDACTED_SOLANA_SECRET_KEY]",
-    },
-
-    // Solana keypair JSON array (64 bytes): [12,34,...] (very common in keypair files)
-    {
-      pattern: /\[(\s*\d{1,3}\s*,){63}\s*\d{1,3}\s*\]/g,
-      replacer: () => "[REDACTED_SOLANA_SECRET_KEY_ARRAY]",
-    },
-
-    // Seed phrase / mnemonic (labeled + heuristic)
-    {
-      pattern:
-        /(mnemonic|seed\s*phrase|recovery\s*phrase|secret\s*phrase)\s*[:=]\s*[a-zA-Z]+(?:\s+[a-zA-Z]+){11,23}|(^|[\n\r\t ])[a-z]+(?: [a-z]+){11,23}(?=($|[\n\r\t ]))/gim,
-      replacer: (value) => redactSeedPhrasesInText(value),
-    },
-
-    // Generic redaction in strings (headers, urls, k/v pairs)
-    {
-      pattern:
-        /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*|\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|passwd|pwd|private[_-]?key|seed(_|-)?phrase|mnemonic)\b\s*[:=]\s*[^\s'"]+|\/\/[^/:\s]+:[^@/\s]+@|[?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|auth|authorization|signature|sig|key|secret|password)=[^&]+/gi,
-      replacer: (value) => redactKeyValuePairs(redactSeedPhrasesInText(value)),
-    },
-  ],
-});
-
-const redactUnknown = (value: unknown): unknown => {
-  try {
-    return redactor.redact(value);
-  } catch {
-    try {
-      const asText = typeof value === "string" ? value : stringify(value);
-      return redactor.redact(asText);
-    } catch {
-      return "[UNSERIALIZABLE]";
-    }
-  }
-};
-
 const formatItem = (item: unknown): string => {
   if (typeof item === "undefined") return "undefined";
 
-  if (typeof item === "string") {
-    const cleaned = redactSeedPhrasesInText(stripAnsi(item));
-    const redacted = redactUnknown(cleaned);
-    return typeof redacted === "string" ? redacted : String(redacted);
-  }
+  // Remove colors from strings
+  if (typeof item === "string")
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
+    return item.replace(/\x1b\[[0-9;]*m/g, "");
 
+  // Check if this is an Error
   const error = ErrorType(item);
-  if (!(error instanceof type.errors)) {
-    const msg = redactSeedPhrasesInText(
-      stripAnsi(error.stack || error.message),
-    );
-    const redacted = redactUnknown(msg);
-    return typeof redacted === "string" ? redacted : String(redacted);
-  }
+  if (!(error instanceof type.errors)) return error.stack || error.message;
 
-  const redacted = redactUnknown(item);
   const stringified = (() => {
     try {
-      return stringify(redacted);
+      return stringify(item);
     } catch {
-      return String(redacted);
+      return String(item);
     }
   })();
 
-  return redactSeedPhrasesInText(stringified).replace(/^'|'$/g, "");
+  return stringified.replace(/^'|'$/g, "");
 };
 
 const format = (items: unknown[]): string =>

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,6 @@
 import { stringify } from "@ungap/structured-clone/json";
 import { type } from "arktype";
+import { redact } from "./redact.js";
 
 const ErrorType = type({
   message: "string",
@@ -12,7 +13,7 @@ const formatItem = (item: unknown): string => {
   // Remove colors from strings
   if (typeof item === "string")
     // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-    return item.replace(/\x1b\[[0-9;]*m/g, "");
+    return redact(item.replace(/\x1b\[[0-9;]*m/g, ""));
 
   // Check if this is an Error
   const error = ErrorType(item);
@@ -26,7 +27,7 @@ const formatItem = (item: unknown): string => {
     }
   })();
 
-  return stringified.replace(/^'|'$/g, "");
+  return redact(stringified.replace(/^'|'$/g, ""));
 };
 
 const format = (items: unknown[]): string =>

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,3 +1,4 @@
+import { DeepRedact } from "@hackylabs/deep-redact/index.ts";
 import { stringify } from "@ungap/structured-clone/json";
 import { type } from "arktype";
 
@@ -6,27 +7,226 @@ const ErrorType = type({
   "stack?": "string",
 });
 
+const stripAnsi = (s: string) =>
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
+  s.replace(/\x1b\[[0-9;]*m/g, "");
+
+const replaceAll = (pattern: RegExp, replacement: string) => (value: string) =>
+  value.replace(pattern, replacement);
+
+const redactKeyValuePairs = (value: string) =>
+  value
+    // Bearer tokens
+    .replace(/\b(Bearer)\s+([A-Za-z0-9\-._~+/]+=*)/gi, "$1 [REDACTED]")
+    // Basic auth header payload
+    .replace(/\b(Basic)\s+([A-Za-z0-9+/=]+)\b/gi, "$1 [REDACTED]")
+    // URL user:pass@
+    .replace(
+      /\/\/([^/:\s]+):([^@/\s]+)@/g,
+      (_m, user) => `//${user}:[REDACTED]@`,
+    )
+    // query params that commonly hold secrets
+    .replace(
+      /([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|auth|authorization|signature|sig|key|secret|password)=)([^&]+)/gi,
+      "$1[REDACTED]",
+    )
+    // generic key=value / key: value
+    .replace(
+      /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|passwd|pwd|private[_-]?key|seed(_|-)?phrase|mnemonic)\b\s*([:=])\s*([^\s'"]+)/gi,
+      (_m, k, sep) => `${k}${sep} [REDACTED]`,
+    );
+
+// Heuristic: likely a seed phrase (12/15/18/21/24 words), especially if labeled
+const redactSeedPhrasesInText = (text: string) => {
+  // Label-based (strong signal)
+  const labeled =
+    /(mnemonic|seed\s*phrase|recovery\s*phrase|secret\s*phrase)\s*[:=]\s*([a-zA-Z]+(?:\s+[a-zA-Z]+){11,23})/gi;
+  text = text.replace(
+    labeled,
+    (_m, label) => `${label}: [REDACTED_SEED_PHRASE]`,
+  );
+
+  // Unlabeled heuristic (weaker, but requested “broad”): redact *only* if it looks like
+  // a standalone phrase (line-ish) with common word counts.
+  const counts = new Set([12, 15, 18, 21, 24]);
+  return text.replace(
+    /(^|[\n\r\t ])([a-z]+(?: [a-z]+){11,23})(?=($|[\n\r\t ]))/g,
+    (m, lead: string, phrase: string) => {
+      const words = phrase.trim().split(/\s+/);
+      if (!counts.has(words.length)) return m;
+      // extra guard to reduce false positives: average word length in typical mnemonics is small-ish
+      const avgLen = words.reduce((a, w) => a + w.length, 0) / words.length;
+      if (avgLen < 3 || avgLen > 8) return m;
+      return `${lead}[REDACTED_SEED_PHRASE]`;
+    },
+  );
+};
+
+const redactor = new DeepRedact({
+  serialise: false,
+  retainStructure: true,
+
+  caseSensitiveKeyMatch: false,
+  fuzzyKeyMatch: true,
+
+  replacement: "[REDACTED]",
+
+  blacklistedKeys: [
+    // common secrets
+    "password",
+    "passwd",
+    "pwd",
+    "pass",
+    "secret",
+    "clientSecret",
+    "privateKey",
+    "apiKey",
+    "apikey",
+    "accessKey",
+    "access_key",
+    "accessToken",
+    "access_token",
+    "refreshToken",
+    "refresh_token",
+    "idToken",
+    "id_token",
+    "token",
+    "authorization",
+    "auth",
+    "cookie",
+    "set-cookie",
+    "session",
+    "sessionid",
+    "session_id",
+
+    // seed phrases / mnemonics
+    "mnemonic",
+    "seedPhrase",
+    "seed_phrase",
+    "recoveryPhrase",
+    "recovery_phrase",
+
+    // headers / env-ish
+    "x-api-key",
+    "x-api-token",
+    "x-auth-token",
+
+    // regex patterns for “key-like” fields
+    {
+      key: /(^|[_-])(api[_-]?key|token|secret|pass(word)?|passwd|pwd|private[_-]?key|auth(orization)?|cookie|session|mnemonic|seed(_|-)?phrase|recovery(_|-)?phrase)([_-]|$)/i,
+    },
+  ],
+
+  stringTests: [
+    // PEM private keys (RSA/EC/DSA/OPENSSH and generic)
+    {
+      pattern:
+        /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
+      replacer: replaceAll(
+        /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
+        "[REDACTED_PRIVATE_KEY]",
+      ),
+    },
+
+    // JWTs
+    {
+      pattern:
+        /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/g,
+      replacer: () => "[REDACTED_JWT]",
+    },
+
+    // Ethereum private key (32 bytes hex; often with 0x)
+    {
+      pattern:
+        /(^|[^a-fA-F0-9])(0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64})(?![a-fA-F0-9])/g,
+      replacer: (value) =>
+        value.replace(
+          /0x[a-fA-F0-9]{64}|[a-fA-F0-9]{64}/g,
+          "[REDACTED_ETH_PRIVATE_KEY]",
+        ),
+    },
+
+    // “64-bit hex strings” (16 hex chars) + other long hex blobs commonly used as secrets.
+    // (This is intentionally broad; remove if too noisy.)
+    {
+      pattern: /\b(?:0x)?[a-fA-F0-9]{16}\b/g,
+      replacer: () => "[REDACTED_HEX]",
+    },
+    {
+      // long hex (>=32) often secrets, hashes, or keys
+      pattern: /\b(?:0x)?[a-fA-F0-9]{32,}\b/g,
+      replacer: () => "[REDACTED_HEX_LONG]",
+    },
+
+    // Solana secret key as base58 string (commonly ~88 chars when encoding 64 bytes)
+    {
+      pattern: /\b[1-9A-HJ-NP-Za-km-z]{80,90}\b/g,
+      replacer: () => "[REDACTED_SOLANA_SECRET_KEY]",
+    },
+
+    // Solana keypair JSON array (64 bytes): [12,34,...] (very common in keypair files)
+    {
+      pattern: /\[(\s*\d{1,3}\s*,){63}\s*\d{1,3}\s*\]/g,
+      replacer: () => "[REDACTED_SOLANA_SECRET_KEY_ARRAY]",
+    },
+
+    // Seed phrase / mnemonic (labeled + heuristic)
+    {
+      pattern:
+        /(mnemonic|seed\s*phrase|recovery\s*phrase|secret\s*phrase)\s*[:=]\s*[a-zA-Z]+(?:\s+[a-zA-Z]+){11,23}|(^|[\n\r\t ])[a-z]+(?: [a-z]+){11,23}(?=($|[\n\r\t ]))/gim,
+      replacer: (value) => redactSeedPhrasesInText(value),
+    },
+
+    // Generic redaction in strings (headers, urls, k/v pairs)
+    {
+      pattern:
+        /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*|\b(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|secret|password|passwd|pwd|private[_-]?key|seed(_|-)?phrase|mnemonic)\b\s*[:=]\s*[^\s'"]+|\/\/[^/:\s]+:[^@/\s]+@|[?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|token|auth|authorization|signature|sig|key|secret|password)=[^&]+/gi,
+      replacer: (value) => redactKeyValuePairs(redactSeedPhrasesInText(value)),
+    },
+  ],
+});
+
+const redactUnknown = (value: unknown): unknown => {
+  try {
+    return redactor.redact(value);
+  } catch {
+    try {
+      const asText = typeof value === "string" ? value : stringify(value);
+      return redactor.redact(asText);
+    } catch {
+      return "[UNSERIALIZABLE]";
+    }
+  }
+};
+
 const formatItem = (item: unknown): string => {
   if (typeof item === "undefined") return "undefined";
 
-  // Remove colors from strings
-  if (typeof item === "string")
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-    return item.replace(/\x1b\[[0-9;]*m/g, "");
+  if (typeof item === "string") {
+    const cleaned = redactSeedPhrasesInText(stripAnsi(item));
+    const redacted = redactUnknown(cleaned);
+    return typeof redacted === "string" ? redacted : String(redacted);
+  }
 
-  // Check if this is an Error
   const error = ErrorType(item);
-  if (!(error instanceof type.errors)) return error.stack || error.message;
+  if (!(error instanceof type.errors)) {
+    const msg = redactSeedPhrasesInText(
+      stripAnsi(error.stack || error.message),
+    );
+    const redacted = redactUnknown(msg);
+    return typeof redacted === "string" ? redacted : String(redacted);
+  }
 
+  const redacted = redactUnknown(item);
   const stringified = (() => {
     try {
-      return stringify(item);
+      return stringify(redacted);
     } catch {
-      return String(item);
+      return String(redacted);
     }
   })();
 
-  return stringified.replace(/^'|'$/g, "");
+  return redactSeedPhrasesInText(stringified).replace(/^'|'$/g, "");
 };
 
 const format = (items: unknown[]): string =>

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,80 @@
+import { DeepRedact } from "@hackylabs/deep-redact/index.ts";
+
+/**
+ * Create a redactor that censors things that *look like secrets* inside strings:
+ * - long hex (optionally 0x-prefixed)
+ * - long base64 blobs
+ * - long base58 blobs
+ * - mnemonic seed phrases (heuristic; tries to avoid redacting normal sentences)
+ *
+ * Returns a function `redactSecrets(text)` you can run on log lines, errors, etc.
+ */
+export const createSecretStringRedactor = (opts?: {
+  replacement?: string;
+}): ((text: string) => string) => {
+  const replacement = opts?.replacement ?? "[REDACTED]";
+
+  // Generic replacer: redact ALL matches within the string.
+  const replaceAllMatches = (value: string, pattern: RegExp) =>
+    value.replace(pattern, replacement);
+
+  // --- Patterns ---
+  // 1) Hex secrets (API keys, hashes, tokens)
+  //    - 32+ hex chars (optionally 0x)
+  //    - word boundaries help avoid eating normal words
+  const HEX = /\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
+
+  // 2) Base64 blobs (JWT parts, keys, encoded payloads)
+  //    - requires a decent minimum length to reduce false positives
+  //    - supports optional padding
+  const BASE64 =
+    /\b(?:[A-Za-z0-9+/]{4}){8,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b/g;
+
+  // 3) Base58 blobs (common in crypto keys/ids)
+  //    - base58 alphabet excludes 0, O, I, l
+  //    - require 32+ chars to reduce false positives
+  const BASE58 = /\b[1-9A-HJ-NP-Za-km-z]{32,}\b/g;
+
+  // 4) Mnemonic seed phrases (heuristic)
+  //    Regex-only detection is imperfect without the BIP39 wordlist.
+  //    Strategy:
+  //      A) Strong signal: a nearby keyword ("seed", "mnemonic", "recovery phrase")
+  //      B) Or the phrase is quoted/bracketed (often how people paste it)
+  //
+  //    - 12 to 24 lowercase-ish words (3–8 chars) separated by spaces
+  //    - kept fairly strict to reduce “normal paragraph” matches
+  const WORD = "[a-z]{3,8}";
+  const PHRASE_12_TO_24 = `(?:${WORD}\\s){11,23}${WORD}`;
+
+  const MNEMONIC_WITH_KEYWORD = new RegExp(
+    // keyword then up to ~40 chars (like ":" or whitespace) then the phrase
+    String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
+    "gi",
+  );
+
+  const MNEMONIC_QUOTED = new RegExp(
+    // quoted/bracketed phrase alone
+    String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
+    "g",
+  );
+
+  const redactor = new DeepRedact({
+    // stringTests runs regex checks against string values (including flat strings)
+    // and lets us partially redact via replacer. :contentReference[oaicite:1]{index=1}
+    stringTests: [
+      { pattern: HEX, replacer: replaceAllMatches },
+      { pattern: BASE64, replacer: replaceAllMatches },
+      { pattern: BASE58, replacer: replaceAllMatches },
+      { pattern: MNEMONIC_WITH_KEYWORD, replacer: replaceAllMatches },
+      { pattern: MNEMONIC_QUOTED, replacer: replaceAllMatches },
+    ],
+    replacement,
+    // serialise mainly matters for objects; keeping it false avoids surprises.
+    serialise: false,
+  });
+
+  return (text: string) => redactor.redact(text) as string;
+};
+
+// Convenience: one-liner function if you don’t need multiple instances
+export const redactSecrets = createSecretStringRedactor();

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -2,85 +2,80 @@ import { DeepRedact } from "@hackylabs/deep-redact/index.ts";
 import { validateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
+const replacement = "[REDACTED]";
+
 /**
- * Create a redactor that censors things that *look like secrets* inside strings:
+ * Create a redactor that censors things that *look like secrets* inside
+ * strings:
  * - long hex (optionally 0x-prefixed)
  * - long base64 blobs
  * - long base58 blobs
  * - mnemonic seed phrases (validated via BIP39 english wordlist)
- *
- * Returns a function `redactSecrets(text)` you can run on log lines, errors, etc.
  */
-export const createSecretStringRedactor = (opts?: {
-  replacement?: string;
-}): ((text: string) => string) => {
-  const replacement = opts?.replacement ?? "[REDACTED]";
 
-  // Generic replacer: redact ALL matches within the string.
-  const replaceAllMatches = (value: string, pattern: RegExp) =>
-    value.replace(pattern, replacement);
+// Generic replacer: redact ALL matches within the string.
+const replaceAllMatches = (value: string, pattern: RegExp) =>
+  value.replace(pattern, replacement);
 
-  // Mnemonic replacer: only redact if the captured phrase is a valid BIP39 mnemonic.
-  const replaceBip39MnemonicMatches = (value: string, pattern: RegExp) =>
-    value.replace(pattern, (match: string, phrase: string) => {
-      // Normalize spacing; validateMnemonic expects words separated by single spaces
-      const normalized = phrase.trim().toLowerCase().replace(/\s+/g, " ");
-      if (!validateMnemonic(normalized, wordlist)) return match;
-      return match.replace(phrase, replacement);
-    });
-
-  // --- Patterns ---
-  // 1) Hex secrets (API keys, hashes, tokens)
-  //    - 32+ hex chars (optionally 0x)
-  //    - word boundaries help avoid eating normal words
-  const HEX = /\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
-
-  // 2) Base64 blobs (JWT parts, keys, encoded payloads)
-  //    - requires a decent minimum length to reduce false positives
-  //    - supports optional padding
-  const BASE64 =
-    /\b(?:[A-Za-z0-9+/]{4}){8,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b/g;
-
-  // 3) Base58 blobs (common in crypto keys/ids)
-  //    - base58 alphabet excludes 0, O, I, l
-  //    - require 32+ chars to reduce false positives
-  const BASE58 = /\b[1-9A-HJ-NP-Za-km-z]{32,}\b/g;
-
-  // 4) Mnemonic seed phrases
-  //    Strategy stays the same as before, but we now validate candidates with @scure/bip39.
-  //    - 12 to 24 lowercase-ish words (2–8 chars) separated by spaces
-  const WORD = "[a-z]{2,8}";
-  const PHRASE_12_TO_24 = `(?:${WORD}\\s){11,23}${WORD}`;
-
-  const MNEMONIC_WITH_KEYWORD = new RegExp(
-    // keyword then up to ~40 chars (like ":" or whitespace) then the phrase
-    String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
-    "gi",
-  );
-
-  const MNEMONIC_QUOTED = new RegExp(
-    // quoted/bracketed phrase alone
-    String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
-    "g",
-  );
-
-  const redactor = new DeepRedact({
-    // stringTests runs regex checks against string values (including flat strings)
-    // and lets us partially redact via replacer.
-    stringTests: [
-      { pattern: HEX, replacer: replaceAllMatches },
-      { pattern: BASE64, replacer: replaceAllMatches },
-      { pattern: BASE58, replacer: replaceAllMatches },
-      { pattern: MNEMONIC_WITH_KEYWORD, replacer: replaceBip39MnemonicMatches },
-      { pattern: MNEMONIC_QUOTED, replacer: replaceBip39MnemonicMatches },
-    ],
-    replacement,
-    // serialise mainly matters for objects; keeping it false avoids surprises.
-    serialise: false,
+// Mnemonic replacer: only redact if the captured phrase is a valid BIP39 mnemonic.
+const replaceBip39MnemonicMatches = (value: string, pattern: RegExp) =>
+  value.replace(pattern, (match: string, phrase: string) => {
+    // Normalize spacing; validateMnemonic expects words separated by single spaces
+    const normalized = phrase.trim().toLowerCase().replace(/\s+/g, " ");
+    if (!validateMnemonic(normalized, wordlist)) return match;
+    return match.replace(phrase, replacement);
   });
 
-  return (text: string) => redactor.redact(text) as string;
-};
+// --- Patterns ---
+// 1) Hex secrets (API keys, hashes, tokens)
+//    - 32+ hex chars (optionally 0x)
+//    - word boundaries help avoid eating normal words
+const HEX = /\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
 
-// Convenience: one-liner function if you don’t need multiple instances
-export const redactSecrets = createSecretStringRedactor();
+// 2) Base64 blobs (JWT parts, keys, encoded payloads)
+//    - requires a decent minimum length to reduce false positives
+//    - supports optional padding
+const BASE64 =
+  /\b(?:[A-Za-z0-9+/]{4}){8,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b/g;
+
+// 3) Base58 blobs (common in crypto keys/ids)
+//    - base58 alphabet excludes 0, O, I, l
+//    - require 32+ chars to reduce false positives
+const BASE58 = /\b[1-9A-HJ-NP-Za-km-z]{32,}\b/g;
+
+// 4) Mnemonic seed phrases
+//    Strategy stays the same as before, but we now validate candidates with @scure/bip39.
+//    - 12 to 24 lowercase-ish words (2–8 chars) separated by spaces
+const WORD = "[a-z]{2,8}";
+const PHRASE_12_TO_24 = `(?:${WORD}\\s){11,23}${WORD}`;
+
+const MNEMONIC_WITH_KEYWORD = new RegExp(
+  // keyword then up to ~40 chars (like ":" or whitespace) then the phrase
+  String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
+  "gi",
+);
+
+const MNEMONIC_QUOTED = new RegExp(
+  // quoted/bracketed phrase alone
+  String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
+  "g",
+);
+
+const redactor = new DeepRedact({
+  // stringTests runs regex checks against string values (including flat strings)
+  // and lets us partially redact via replacer.
+  stringTests: [
+    { pattern: HEX, replacer: replaceAllMatches },
+    { pattern: BASE64, replacer: replaceAllMatches },
+    { pattern: BASE58, replacer: replaceAllMatches },
+    { pattern: MNEMONIC_WITH_KEYWORD, replacer: replaceBip39MnemonicMatches },
+    { pattern: MNEMONIC_QUOTED, replacer: replaceBip39MnemonicMatches },
+  ],
+  replacement,
+  // serialise mainly matters for objects; keeping it false avoids surprises.
+  serialise: false,
+});
+
+const redact = (text: string) => redactor.redact(text) as string;
+
+export { redact };

--- a/src/types/ungap-structured-clone-json.d.ts
+++ b/src/types/ungap-structured-clone-json.d.ts
@@ -1,0 +1,10 @@
+declare module "@ungap/structured-clone/json" {
+  export function stringify(
+    value: unknown,
+    replacer?:
+      | ((this: unknown, key: string, value: unknown) => unknown)
+      | (number | string)[]
+      | null,
+    space?: string | number,
+  ): string;
+}

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -1,4 +1,4 @@
-import { setupLogging } from "mynth-logger";
+import { setupLogging } from "../src/index.js";
 
 const run = async () => {
   setupLogging();

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -8,6 +8,12 @@ const run = async () => {
   console.debug("Hello, this is a debug log");
   console.warn("Hello, this is a warn log");
   console.error("Hello, this is an error log");
+  console.log(
+    "This is my seed phrase: ordinary quality amount solid fox guess peasant merit midnight noodle final brown pretty stable six fox beef engage waste uniform evoke flat survey crane",
+  );
+  console.log(
+    "This is my private key: 4fa7614bdd07ab15b11d2365466536ba160c06050ade0888a3aa985a5522ab22",
+  );
 
   try {
     throw new Error("An Error was thrown");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -18,4 +18,11 @@ describe("logging", () => {
     console.debug(false, true, "true", "false");
     expect(true).toBe(true);
   });
+
+  it("redacts private key", () => {
+    console.info(
+      "a723cc20646a45cccd045b4bd13c0f73e505e6fc7f0c5006ab62e0410a2ef9ba",
+    );
+    expect(true).toBe(true);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
-    "target": "es2022",
-    "module": "es2022",
-    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR integrates a `DeepRedact`-based sanitizer to automatically redact values that look like secrets before they reach production logs.

The goal is to prevent accidental leakage of sensitive material such as API keys, private keys, JWT payloads, seed phrases, and other credential-like strings.

All detected secrets are replaced with:

```
[REDACTED]
```

### Example

**Input**

```
User provided seed: legal winner thank year wave sausage worth useful legal winner thank yellow
JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
```

**Output**

```
User provided seed: [REDACTED]
JWT: [REDACTED]
```