### PR TITLE
Make redaction configurable with context-aware allow rules

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,10 @@
 import { stringify } from "@ungap/structured-clone/json";
 import { type } from "arktype";
-import { redact } from "./redact.js";
+import { createRedact } from "./redact.js";
+
+const redact = createRedact({
+  hex: { enabled: true, allow: [{ re: /\b(intent|hash)\b/i }] },
+});
 
 const ErrorType = type({
   message: "string",

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,10 +1,14 @@
 import { stringify } from "@ungap/structured-clone/json";
 import { type } from "arktype";
-import { createRedact } from "./redact.js";
+import { createRedact, type RedactConfig } from "./redact.js";
 
-const redact = createRedact({
-  hex: { enabled: true, allow: [{ re: /\b(intent|hash)\b/i }] },
-});
+const config = {
+  redact: createRedact({}),
+};
+
+const updateConfig = (newConfig: RedactConfig) => {
+  config.redact = createRedact(newConfig);
+};
 
 const ErrorType = type({
   message: "string",
@@ -17,7 +21,7 @@ const formatItem = (item: unknown): string => {
   // Remove colors from strings
   if (typeof item === "string")
     // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-    return redact(item.replace(/\x1b\[[0-9;]*m/g, ""));
+    return config.redact(item.replace(/\x1b\[[0-9;]*m/g, ""));
 
   // Check if this is an Error
   const error = ErrorType(item);
@@ -31,7 +35,7 @@ const formatItem = (item: unknown): string => {
     }
   })();
 
-  return redact(stringified.replace(/^'|'$/g, ""));
+  return config.redact(stringified.replace(/^'|'$/g, ""));
 };
 
 const format = (items: unknown[]): string =>
@@ -39,4 +43,4 @@ const format = (items: unknown[]): string =>
     .map((item) => formatItem(item))
     .join(" ");
 
-export { format };
+export { format, updateConfig };

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,4 +1,4 @@
-import { ConsolaOptions, createConsola } from "consola";
+import { createConsola } from "consola";
 import { updateConfig } from "./format.js";
 import type { RedactConfig } from "./redact.js";
 import DatadogReporter from "./reporters/datadog.js";
@@ -6,7 +6,7 @@ import DiscordReporter from "./reporters/discord.js";
 
 const setupLogging = (config: RedactConfig = {}) => {
   updateConfig(config);
-  const consola = createConsola({ fancy: true, level: 5 } as Options);
+  const consola = createConsola({ fancy: true, level: 5 });
 
   if (process.env.NODE_ENV === "production")
     consola.setReporters([DatadogReporter]);
@@ -19,7 +19,5 @@ const setupLogging = (config: RedactConfig = {}) => {
   consola.wrapConsole();
   return consola;
 };
-
-type Options = ConsolaOptions & { fancy?: boolean };
 
 export { setupLogging };

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,8 +1,11 @@
 import { ConsolaOptions, createConsola } from "consola";
+import { updateConfig } from "./format.js";
+import type { RedactConfig } from "./redact.js";
 import DatadogReporter from "./reporters/datadog.js";
 import DiscordReporter from "./reporters/discord.js";
 
-const setupLogging = () => {
+const setupLogging = (config: RedactConfig = {}) => {
+  updateConfig(config);
   const consola = createConsola({ fancy: true, level: 5 } as Options);
 
   if (process.env.NODE_ENV === "production")

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -10,11 +10,10 @@ const setupLogging = (config: RedactConfig = {}) => {
 
   if (process.env.NODE_ENV === "production")
     consola.setReporters([DatadogReporter]);
-
   // Set Discord reporter as first so it can remove
   // Discord-related config before other reporters process the
   // log
-  consola.setReporters([DiscordReporter, ...consola.options.reporters]);
+  else consola.setReporters([DiscordReporter, ...consola.options.reporters]);
 
   consola.wrapConsole();
   return consola;

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -32,7 +32,7 @@ const replaceBip39MnemonicMatches = (value: string, pattern: RegExp) =>
 // 1) Hex secrets (API keys, hashes, tokens)
 //    - 32+ hex chars (optionally 0x)
 //    - word boundaries help avoid eating normal words
-const HEX = /\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
+const HEX = /(?<!\bintent\s)(?<!\bhash\s)\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
 
 // 2) Base64 blobs (JWT parts, keys, encoded payloads)
 //    - requires a decent minimum length to reduce false positives

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -2,88 +2,319 @@ import { DeepRedact } from "@hackylabs/deep-redact/index.ts";
 import { validateMnemonic } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english.js";
 
-const replacement = "[REDACTED]";
-
 /**
- * Create a redactor that censors things that *look like secrets* inside
- * strings:
- * - long hex (optionally 0x-prefixed)
- * - long base64 blobs
- * - long base58 blobs
- * - mnemonic seed phrases (validated via BIP39 english wordlist)
+ * Configurable redaction for strings that *look like secrets*:
+ * - hex (optionally 0x-prefixed)
+ * - base64 blobs
+ * - base58 blobs
+ * - BIP39 mnemonics (validated)
+ *
+ * Key idea:
+ * Each detector can be given "allow" context rules that prevent redaction when
+ * extra surrounding context indicates the value is safe/expected.
  */
 
-// Generic replacer: redact ALL matches within the string.
-const replaceAllMatches = (value: string, pattern: RegExp) =>
-  value.replace(pattern, replacement);
+type ContextRule = {
+  /**
+   * Test this regex against a slice of the input around the match.
+   * If it matches, the secret is NOT redacted.
+   */
+  re: RegExp;
+  /** How many chars to include before the match when building the slice. */
+  before?: number; // default 0
+  /** How many chars to include after the match when building the slice. */
+  after?: number; // default 0
+};
 
-// Mnemonic replacer: only redact if the captured phrase is a valid BIP39 mnemonic.
-const replaceBip39MnemonicMatches = (value: string, pattern: RegExp) =>
-  value.replace(pattern, (match: string, phrase: string) => {
-    // Normalize spacing; validateMnemonic expects words separated by single spaces
-    const normalized = phrase.trim().toLowerCase().replace(/\s+/g, " ");
-    if (!validateMnemonic(normalized, wordlist)) return match;
+type DetectorConfig = {
+  enabled?: boolean;
+  /**
+   * Any rule match => do not redact that specific match.
+   * Useful for things like "hash: <sha256>" or "intent <hex>".
+   */
+  allow?: ContextRule[];
+};
 
-    // Replace only the phrase portion (preserves surrounding quotes/keywords if any)
-    return match.replace(phrase, replacement);
+type RedactConfig = {
+  replacement?: string;
+
+  hex?: DetectorConfig & {
+    /** Minimum number of hex chars (excluding optional 0x). Default 32. */
+    minLen?: number;
+    /** Allow-list keywords for the common “keyword: <hex>” case. */
+    allowKeywords?: string[]; // e.g. ["intent", "hash"]
+    /**
+     * How far back from the match to look for an allowKeyword.
+     * (handles "hash:", "hash = ", etc.)
+     */
+    keywordWindow?: number; // default 40
+  };
+
+  base64?: DetectorConfig & {
+    /** Minimum number of 4-char blocks. Default 8 (same as your current regex). */
+    minBlocks?: number;
+  };
+
+  base58?: DetectorConfig & {
+    /** Minimum number of chars. Default 32. */
+    minLen?: number;
+  };
+
+  mnemonic?: DetectorConfig & {
+    /** Enable/disable bare mnemonics (no keyword, no quotes). Default true. */
+    bare?: boolean;
+    /** Enable/disable keyword-triggered mnemonics. Default true. */
+    withKeyword?: boolean;
+    /** Enable/disable quoted/bracketed mnemonics. Default true. */
+    quoted?: boolean;
+  };
+
+  /**
+   * DeepRedact option; default false (matches your current behavior).
+   * (Keep false to avoid surprises.)
+   */
+  serialise?: boolean;
+};
+
+const DEFAULT_REPLACEMENT = "[REDACTED]";
+
+const sliceAround = (
+  value: string,
+  offset: number,
+  matchLen: number,
+  rule: ContextRule,
+) => {
+  const before = rule.before ?? 10;
+  const after = rule.after ?? 0;
+
+  const start = Math.max(0, offset - before);
+  const end = Math.min(value.length, offset + matchLen + after);
+  return value.slice(start, end);
+};
+
+const shouldAllowByRules = (
+  value: string,
+  match: string,
+  offset: number,
+  rules?: ContextRule[],
+): boolean => {
+  if (!rules?.length) return false;
+  for (const rule of rules) {
+    const chunk = sliceAround(value, offset, match.length, rule);
+    if (rule.re.test(chunk)) return true;
+  }
+  return false;
+};
+
+/**
+ * Generic contextual replacer:
+ * - Redacts every match unless an allow-rule matches nearby context.
+ */
+const replaceAllMatchesWithContext = (
+  value: string,
+  pattern: RegExp,
+  replacement: string,
+  allow?: ContextRule[],
+) => {
+  return value.replace(pattern, (match, ...args: any[]) => {
+    const offset = args[args.length - 2] as number; // replace() callback signature
+    const whole = args[args.length - 1] as string;
+
+    // If allow rules match context, keep original match
+    if (shouldAllowByRules(whole, match, offset, allow)) return match;
+
+    return replacement;
   });
+};
 
-// --- Patterns ---
-// 1) Hex secrets (API keys, hashes, tokens)
-//    - 32+ hex chars (optionally 0x)
-//    - word boundaries help avoid eating normal words
-const HEX = /(?<!\bintent\s)(?<!\bhash\s)\b(?:0x)?[a-fA-F0-9]{32,}\b/g;
+/**
+ * BIP39 contextual replacer:
+ * - Only redacts if the captured phrase validates as a BIP39 mnemonic
+ * - Still supports allow-rules (to suppress redaction in “safe” contexts)
+ */
+const replaceBip39MnemonicMatchesWithContext = (
+  value: string,
+  pattern: RegExp,
+  replacement: string,
+  allow?: ContextRule[],
+) => {
+  return value.replace(
+    pattern,
+    (match: string, phrase: string, ...rest: any[]) => {
+      const offset = rest[rest.length - 2] as number;
+      const whole = rest[rest.length - 1] as string;
 
-// 2) Base64 blobs (JWT parts, keys, encoded payloads)
-//    - requires a decent minimum length to reduce false positives
-//    - supports optional padding
-const BASE64 =
-  /\b(?:[A-Za-z0-9+/]{4}){8,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b/g;
+      if (shouldAllowByRules(whole, match, offset, allow)) return match;
 
-// 3) Base58 blobs (common in crypto keys/ids)
-//    - base58 alphabet excludes 0, O, I, l
-//    - require 32+ chars to reduce false positives
-const BASE58 = /\b[1-9A-HJ-NP-Za-km-z]{32,}\b/g;
+      const normalized = phrase.trim().toLowerCase().replace(/\s+/g, " ");
+      if (!validateMnemonic(normalized, wordlist)) return match;
 
-// 4) Mnemonic seed phrases
-//    We validate candidates with @scure/bip39 to avoid false positives.
-//    - 12 to 24 words separated by whitespace
-const WORD = "[a-zA-Z]{2,8}";
-const PHRASE_12_TO_24 = `(?:${WORD}\\s+){11,23}${WORD}`;
+      // Replace only the phrase portion (preserves surrounding quotes/keywords if any)
+      return match.replace(phrase, replacement);
+    },
+  );
+};
 
-const MNEMONIC_WITH_KEYWORD = new RegExp(
-  // keyword then up to ~40 chars (like ":" or whitespace) then the phrase
-  String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
-  "gi",
-);
+const escapeForRegexLiteral = (s: string) =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const MNEMONIC_QUOTED = new RegExp(
-  // quoted/bracketed phrase alone
-  String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
-  "gi",
-);
+/**
+ * Build a context rule that allows a match when a keyword appears shortly before it,
+ * like: "hash: <hex>" or "intent = <hex>".
+ */
+const keywordAllowRules = (
+  keywords: string[],
+  window: number,
+): ContextRule[] => {
+  if (!keywords.length) return [];
+  const kw = keywords.map(escapeForRegexLiteral).join("|");
+  // keyword, then optional separators/spaces up to the window end.
+  // We only examine the chunk BEFORE the match by slicing.
+  return [
+    {
+      re: new RegExp(String.raw`\b(?:${kw})\b[\s:=-]{0,40}$`, "i"),
+      before: window,
+      after: 0,
+    },
+  ];
+};
 
-// NEW: Bare mnemonic phrases (no keyword, no quotes).
-// This is what your console.log example is: just the phrase by itself.
-// Validation keeps false-positives low.
-const MNEMONIC_BARE = new RegExp(String.raw`\b(${PHRASE_12_TO_24})\b`, "gi");
+const createRedactor = (config: RedactConfig = {}) => {
+  const replacement = config.replacement ?? DEFAULT_REPLACEMENT;
 
-const redactor = new DeepRedact({
-  // stringTests runs regex checks against string values (including flat strings)
-  // and lets us partially redact via replacer.
-  stringTests: [
-    { pattern: HEX, replacer: replaceAllMatches },
-    { pattern: BASE64, replacer: replaceAllMatches },
-    { pattern: BASE58, replacer: replaceAllMatches },
-    { pattern: MNEMONIC_WITH_KEYWORD, replacer: replaceBip39MnemonicMatches },
-    { pattern: MNEMONIC_QUOTED, replacer: replaceBip39MnemonicMatches },
-    { pattern: MNEMONIC_BARE, replacer: replaceBip39MnemonicMatches },
-  ],
-  replacement,
-  // serialise mainly matters for objects; keeping it false avoids surprises.
-  serialise: false,
-});
+  // ---- Patterns (built from config) ----
 
-const redact = (text: string) => redactor.redact(text) as string;
+  // 1) HEX
+  const hexEnabled = config.hex?.enabled ?? true;
+  const hexMinLen = config.hex?.minLen ?? 32;
+  const hexAllowKeywords = config.hex?.allowKeywords ?? ["intent", "hash"];
+  const hexKeywordWindow = config.hex?.keywordWindow ?? 40;
 
-export { redact };
+  const HEX = new RegExp(
+    String.raw`\b(?:0x)?[a-fA-F0-9]{${hexMinLen},}\b`,
+    "g",
+  );
+  const hexAllow: ContextRule[] = [
+    ...keywordAllowRules(hexAllowKeywords, hexKeywordWindow),
+    ...(config.hex?.allow ?? []),
+  ];
+
+  // 2) BASE64
+  const base64Enabled = config.base64?.enabled ?? true;
+  const base64MinBlocks = config.base64?.minBlocks ?? 8;
+  // same shape as your original, but min blocks configurable
+  const BASE64 = new RegExp(
+    String.raw`\b(?:[A-Za-z0-9+/]{4}){${base64MinBlocks},}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b`,
+    "g",
+  );
+  const base64Allow = config.base64?.allow ?? [];
+
+  // 3) BASE58
+  const base58Enabled = config.base58?.enabled ?? true;
+  const base58MinLen = config.base58?.minLen ?? 32;
+  const BASE58 = new RegExp(
+    String.raw`\b[1-9A-HJ-NP-Za-km-z]{${base58MinLen},}\b`,
+    "g",
+  );
+  const base58Allow = config.base58?.allow ?? [];
+
+  // 4) MNEMONIC seed phrases
+  const mnemonicEnabled = config.mnemonic?.enabled ?? true;
+  const mnemonicBare = config.mnemonic?.bare ?? true;
+  const mnemonicWithKeyword = config.mnemonic?.withKeyword ?? true;
+  const mnemonicQuoted = config.mnemonic?.quoted ?? true;
+
+  const WORD = "[a-zA-Z]{2,8}";
+  const PHRASE_12_TO_24 = `(?:${WORD}\\s+){11,23}${WORD}`;
+
+  const MNEMONIC_WITH_KEYWORD = new RegExp(
+    String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
+    "gi",
+  );
+
+  const MNEMONIC_QUOTED = new RegExp(
+    String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
+    "gi",
+  );
+
+  const MNEMONIC_BARE = new RegExp(String.raw`\b(${PHRASE_12_TO_24})\b`, "gi");
+
+  const mnemonicAllow = config.mnemonic?.allow ?? [];
+
+  const stringTests: Array<{
+    pattern: RegExp;
+    replacer: (v: string, p: RegExp) => string;
+  }> = [];
+
+  if (hexEnabled)
+    stringTests.push({
+      pattern: HEX,
+      replacer: (v, p) =>
+        replaceAllMatchesWithContext(v, p, replacement, hexAllow),
+    });
+
+  if (base64Enabled)
+    stringTests.push({
+      pattern: BASE64,
+      replacer: (v, p) =>
+        replaceAllMatchesWithContext(v, p, replacement, base64Allow),
+    });
+
+  if (base58Enabled)
+    stringTests.push({
+      pattern: BASE58,
+      replacer: (v, p) =>
+        replaceAllMatchesWithContext(v, p, replacement, base58Allow),
+    });
+
+  if (mnemonicEnabled) {
+    if (mnemonicWithKeyword)
+      stringTests.push({
+        pattern: MNEMONIC_WITH_KEYWORD,
+        replacer: (v, p) =>
+          replaceBip39MnemonicMatchesWithContext(
+            v,
+            p,
+            replacement,
+            mnemonicAllow,
+          ),
+      });
+
+    if (mnemonicQuoted)
+      stringTests.push({
+        pattern: MNEMONIC_QUOTED,
+        replacer: (v, p) =>
+          replaceBip39MnemonicMatchesWithContext(
+            v,
+            p,
+            replacement,
+            mnemonicAllow,
+          ),
+      });
+
+    if (mnemonicBare)
+      stringTests.push({
+        pattern: MNEMONIC_BARE,
+        replacer: (v, p) =>
+          replaceBip39MnemonicMatchesWithContext(
+            v,
+            p,
+            replacement,
+            mnemonicAllow,
+          ),
+      });
+  }
+
+  return new DeepRedact({
+    stringTests,
+    replacement,
+    serialise: config.serialise ?? false,
+  });
+};
+
+const createRedact = (config: RedactConfig = {}) => {
+  const redactor = createRedactor(config);
+  return (text: string) => redactor.redact(text) as string;
+};
+
+export { createRedact };

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -178,21 +178,11 @@ const createRedactor = (config: RedactConfig = {}) => {
   );
   const base58Allow = config.base58?.allow ?? [];
 
-  // 4) MNEMONIC seed phrases (all variants enabled by default now)
+  // 4) MNEMONIC seed phrases (bare variant only)
   const mnemonicEnabled = config.mnemonic?.enabled ?? true;
 
   const WORD = "[a-zA-Z]{2,8}";
   const PHRASE_12_TO_24 = `(?:${WORD}\\s+){11,23}${WORD}`;
-
-  const MNEMONIC_WITH_KEYWORD = new RegExp(
-    String.raw`\b(?:mnemonic|seed|recovery\s+phrase|secret\s+phrase)\b[\s:=-]{0,40}(${PHRASE_12_TO_24})\b`,
-    "gi",
-  );
-
-  const MNEMONIC_QUOTED = new RegExp(
-    String.raw`(?:["'(\[])\s*(${PHRASE_12_TO_24})\s*(?:["')\]])`,
-    "gi",
-  );
 
   const MNEMONIC_BARE = new RegExp(String.raw`\b(${PHRASE_12_TO_24})\b`, "gi");
 
@@ -225,31 +215,7 @@ const createRedactor = (config: RedactConfig = {}) => {
     });
 
   if (mnemonicEnabled) {
-    // with keyword
-    stringTests.push({
-      pattern: MNEMONIC_WITH_KEYWORD,
-      replacer: (v, p) =>
-        replaceBip39MnemonicMatchesWithContext(
-          v,
-          p,
-          replacement,
-          mnemonicAllow,
-        ),
-    });
-
-    // quoted
-    stringTests.push({
-      pattern: MNEMONIC_QUOTED,
-      replacer: (v, p) =>
-        replaceBip39MnemonicMatchesWithContext(
-          v,
-          p,
-          replacement,
-          mnemonicAllow,
-        ),
-    });
-
-    // bare
+    // bare only
     stringTests.push({
       pattern: MNEMONIC_BARE,
       replacer: (v, p) =>

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -21,7 +21,7 @@ type ContextRule = {
    */
   re: RegExp;
   /** How many chars to include before the match when building the slice. */
-  before?: number; // default 0
+  before?: number; // default 10
   /** How many chars to include after the match when building the slice. */
   after?: number; // default 0
 };

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -269,9 +269,10 @@ const createRedactor = (config: RedactConfig = {}) => {
   });
 };
 
-const createRedact = (config: RedactConfig = {}) => {
+const createRedact = (config: RedactConfig) => {
   const redactor = createRedactor(config);
   return (text: string) => redactor.redact(text) as string;
 };
 
 export { createRedact };
+export type { RedactConfig };

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -34,21 +34,13 @@ type DetectorConfig = {
 };
 
 type RedactConfig = {
-  replacement?: string;
-
   hex?: DetectorConfig;
   base64?: DetectorConfig;
   base58?: DetectorConfig;
   mnemonic?: DetectorConfig;
-
-  /**
-   * DeepRedact option; default false (matches your current behavior).
-   * (Keep false to avoid surprises.)
-   */
-  serialise?: boolean;
 };
 
-const DEFAULT_REPLACEMENT = "[REDACTED]";
+const replacement = "[REDACTED]";
 
 const sliceAround = (
   value: string,
@@ -138,7 +130,6 @@ const replaceBip39MnemonicMatchesWithContext = (
   });
 
 const createRedactor = (config: RedactConfig = {}) => {
-  const replacement = config.replacement ?? DEFAULT_REPLACEMENT;
   const HEX_MIN_LEN = 32;
   const BASE64_MIN_BLOCKS = 8;
   const BASE58_MIN_LEN = 32;
@@ -205,7 +196,7 @@ const createRedactor = (config: RedactConfig = {}) => {
   return new DeepRedact({
     stringTests,
     replacement,
-    serialise: config.serialise ?? false,
+    serialise: false,
   });
 };
 

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -134,21 +134,18 @@ const createRedactor = (config: RedactConfig = {}) => {
   const BASE64_MIN_BLOCKS = 8;
   const BASE58_MIN_LEN = 32;
 
-  // 1) HEX
   const HEX = new RegExp(
     String.raw`\b(?:0x)?[a-fA-F0-9]{${HEX_MIN_LEN},}\b`,
     "g",
   );
   const hexAllow: ContextRule[] = config.hex?.allow ?? [];
 
-  // 2) BASE64
   const BASE64 = new RegExp(
     String.raw`\b(?:[A-Za-z0-9+/]{4}){${BASE64_MIN_BLOCKS},}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\b`,
     "g",
   );
   const base64Allow = config.base64?.allow ?? [];
 
-  // 3) BASE58
   const BASE58 = new RegExp(
     String.raw`\b[1-9A-HJ-NP-Za-km-z]{${BASE58_MIN_LEN},}\b`,
     "g",
@@ -157,9 +154,7 @@ const createRedactor = (config: RedactConfig = {}) => {
 
   const WORD = "[a-zA-Z]{2,8}";
   const PHRASE_12_TO_24 = `(?:${WORD}\\s+){11,23}${WORD}`;
-
-  const MNEMONIC_BARE = new RegExp(String.raw`\b(${PHRASE_12_TO_24})\b`, "gi");
-
+  const MNEMONIC = new RegExp(String.raw`\b(${PHRASE_12_TO_24})\b`, "gi");
   const mnemonicAllow = config.mnemonic?.allow ?? [];
 
   const stringTests: Array<{
@@ -182,7 +177,7 @@ const createRedactor = (config: RedactConfig = {}) => {
         replaceAllMatchesWithContext(v, p, replacement, base58Allow),
     },
     {
-      pattern: MNEMONIC_BARE,
+      pattern: MNEMONIC,
       replacer: (v, p) =>
         replaceBip39MnemonicMatchesWithContext(
           v,

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -14,6 +14,9 @@ const run = async () => {
   console.log(
     "This is my private key: 4fa7614bdd07ab15b11d2365466536ba160c06050ade0888a3aa985a5522ab22",
   );
+  console.log(
+    "This is log for intent c8adcfef7255ad2c117f68111500997ab66de3c923e9ea9e71aaed5829d0acb8 and private key c99960eaeecb17d77d7c88f440383ccbaf93237471236a739185c0ebd62c5741",
+  );
 
   try {
     throw new Error("An Error was thrown");

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -2,7 +2,7 @@ import { setupLogging } from "../src/index.js";
 
 const run = async () => {
   setupLogging({
-    hex: { enabled: true, allow: [{ re: /\b(intent|hash)\b/i }] },
+    hex: { allow: [{ re: /\b(intent|hash)\b/i }] },
   });
 
   console.log("Hello, this is a log");

--- a/tests/app.ts
+++ b/tests/app.ts
@@ -1,7 +1,9 @@
 import { setupLogging } from "../src/index.js";
 
 const run = async () => {
-  setupLogging();
+  setupLogging({
+    hex: { enabled: true, allow: [{ re: /\b(intent|hash)\b/i }] },
+  });
 
   console.log("Hello, this is a log");
   console.info("Hello, this is an info log");


### PR DESCRIPTION
This PR refactors the redaction system to make it configurable and context-aware, allowing selective suppression of redaction based on surrounding text.

#### Context-Aware Allow Rules

Each detector (hex, base64, base58, mnemonic) now supports:

```ts
type ContextRule = {
  re: RegExp;
  before?: number; // default 10
  after?: number;  // default 0
};
```

If a rule matches the surrounding slice of text, that specific match is not redacted.

This enables cases like:

* Allowing hashes when used in known safe contexts (e.g. “intent”, “hash”)
* Still redacting private keys or other sensitive material

#### Logging Setup Adjustment

* `setupLogging` now takes an optional redaction config