### PR TITLE
Fix redaction regex reuse: avoid mutating patterns and keep allowlist working across calls

### DIFF
--- a/src/redact.ts
+++ b/src/redact.ts
@@ -44,11 +44,6 @@ type RedactConfig = {
 
 const replacement = "[REDACTED]";
 
-const cloneRegex = (re: RegExp): RegExp => {
-  const flags = re.flags.includes("g") ? re.flags : `${re.flags}g`;
-  return new RegExp(re.source, flags);
-};
-
 const sliceAround = (
   value: string,
   offset: number,
@@ -100,9 +95,8 @@ const replaceAllMatchesWithContext = (
   pattern: RegExp,
   replacement: string,
   allow?: ContextRule[],
-) => {
-  const re = cloneRegex(pattern);
-  return value.replace(re, (...args: unknown[]) => {
+) =>
+  value.replace(pattern, (...args: unknown[]) => {
     const match = args[0];
     if (typeof match !== "string") return replacement;
 
@@ -112,7 +106,6 @@ const replaceAllMatchesWithContext = (
     if (shouldAllowByRules(meta.whole, match, meta.offset, allow)) return match;
     return replacement;
   });
-};
 
 /**
  * BIP39 contextual replacer:
@@ -124,9 +117,8 @@ const replaceBip39MnemonicMatchesWithContext = (
   pattern: RegExp,
   replacement: string,
   allow?: ContextRule[],
-) => {
-  const re = cloneRegex(pattern);
-  return value.replace(re, (...args: unknown[]) => {
+) =>
+  value.replace(pattern, (...args: unknown[]) => {
     const match = args[0];
     const phrase = args[1];
 
@@ -143,7 +135,6 @@ const replaceBip39MnemonicMatchesWithContext = (
 
     return match.replace(phrase, replacement);
   });
-};
 
 const createRedactor = (config: RedactConfig = {}) => {
   const HEX_MIN_LEN = 16;
@@ -152,25 +143,21 @@ const createRedactor = (config: RedactConfig = {}) => {
 
   const HEX = new RegExp(
     String.raw`(?<![a-fA-F0-9])(?:0x)?[a-fA-F0-9]{${HEX_MIN_LEN},}(?![a-fA-F0-9])`,
-    "g",
   );
   const hexAllow: ContextRule[] = config.hex?.allow ?? [];
 
   const BASE64 = new RegExp(
     String.raw`(?<![A-Za-z0-9+/=])(?:[A-Za-z0-9+/]{4}){${BASE64_MIN_BLOCKS},}(?:[A-Za-z0-9+/]{2,3})?(?:={0,2})(?![A-Za-z0-9+/=])`,
-    "g",
   );
   const base64Allow = config.base64?.allow ?? [];
 
   const BASE64URL = new RegExp(
     String.raw`(?<![A-Za-z0-9\-_])[A-Za-z0-9\-_]{16,}(?:={0,2})?(?![A-Za-z0-9\-_])`,
-    "g",
   );
   const base64urlAllow = config.base64url?.allow ?? [];
 
   const BASE58 = new RegExp(
     String.raw`(?<![1-9A-HJ-NP-Za-km-z])[1-9A-HJ-NP-Za-km-z]{${BASE58_MIN_LEN},}(?![1-9A-HJ-NP-Za-km-z])`,
-    "g",
   );
   const base58Allow = config.base58?.allow ?? [];
 
@@ -178,7 +165,7 @@ const createRedactor = (config: RedactConfig = {}) => {
   const PHRASE_12_TO_24 = `(?:${WORD}\\s+){11,23}${WORD}`;
   const MNEMONIC = new RegExp(
     String.raw`(?<![A-Za-z])(${PHRASE_12_TO_24})(?![A-Za-z])`,
-    "gi",
+    "i",
   );
   const mnemonicAllow = config.mnemonic?.allow ?? [];
 

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -31,4 +31,14 @@ describe("redact", () => {
       );
     }
   });
+
+  it("redacts multiple hex in same string", () => {
+    const redact = createRedact({});
+    const result = redact(
+      "Pushed event fcc6533b59301096a973b8be3e6518f0cd13f73a9821de558cca77ac9b014d6e.1561338e25f9b57a9babc7ad57a0e0ee0b13a7094a895319883c7daf4a869642 with key d13821711360de832b80be20507912cebe123ebe52240ae91e6a699b72beb26a",
+    );
+    expect(result).toBe(
+      "Pushed event [REDACTED].[REDACTED] with key [REDACTED]",
+    );
+  });
 });

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -19,4 +19,16 @@ describe("redact", () => {
       "Should redact private key ([REDACTED]) and API key ([REDACTED])",
     );
   });
+
+  it("allows whitelist each time", () => {
+    const redact = createRedact({ hex: { allow: [{ re: /\b(event)\b/i }] } });
+    for (let i = 0; i < 10; i++) {
+      const result = redact(
+        "Pushed event fcc6533b59301096a973b8be3e6518f0cd13f73a9821de558cca77ac9b014d6e.1771865100000",
+      );
+      expect(result).toBe(
+        "Pushed event fcc6533b59301096a973b8be3e6518f0cd13f73a9821de558cca77ac9b014d6e.1771865100000",
+      );
+    }
+  });
 });


### PR DESCRIPTION
This PR fixes a subtle statefulness bug in the redactor caused by cloning regexes and forcibly adding the global (`g`) flag.

### What changed
* Removed `cloneRegex`, which was creating new `RegExp` instances with `g` appended.
* Updated `replaceAllMatchesWithContext` and `replaceBip39MnemonicMatchesWithContext` to use the provided `pattern` directly in `String.prototype.replace`.
* Removed explicit `"g"` flags from the internal HEX / BASE64 / BASE64URL / BASE58 regexes and adjusted the mnemonic regex from `"gi"` to `"i"` to avoid unnecessary global state.

### Why
Cloning and forcing `g` can make matching behavior unexpectedly stateful (via `lastIndex`) and can also change how callers’ patterns behave. In practice, this could cause allowlist rules to stop matching reliably after repeated invocations, depending on how the regex is reused.

### Tests
* Added a regression test (`allows whitelist each time`) that calls the redactor repeatedly with a hex allow rule and asserts the allowlist continues to apply on every run.

### Impact
* Redaction behavior is now deterministic across repeated calls.
* Allowlist rules remain effective even when the redactor is invoked many times in a row.